### PR TITLE
Specify pkg.files to exclude tests and examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,9 @@
   },
   "scripts": {
     "test": "standard && mocha"
-  }
+  },
+  "files": [
+    "lib",
+    "bin"
+  ]
 }


### PR DESCRIPTION
I made this consistent with your other packages but used pkg.files instead of npmignore. readme/package/license/changelog are auto-included by npm.